### PR TITLE
fix some configure and command because of axstd

### DIFF
--- a/docs/src/ch03-01.md
+++ b/docs/src/ch03-01.md
@@ -54,7 +54,7 @@ call {init_mmu}
 此时我们只需执行: 
 
 ```shell
-make ARCH=riscv64 A=apps/helloworld run
+make PLATFORM=riscv64-qemu-virt A=apps/helloworld run
 ```
 
  如无意外， 我们在打印 ArceOS 的 LOGO 之前看到了我们调用 putchar 函数进行的输出 "HELLO FROM SBI"， 当然，每个字符的输出只需要在 console_putchar 中自行添加即可。 

--- a/docs/src/ch03-02.md
+++ b/docs/src/ch03-02.md
@@ -39,7 +39,7 @@ unsafe extern "C" fn rust_entry(cpu_id: usize, dtb: usize) {
 执行: 
 
 ```shell
-make ARCH=riscv64 A=apps/helloworld run
+make PLATFORM=riscv64-qemu-virt A=apps/helloworld run
 ```
 
  如无意外， helloworld成功输出！说明我们的思路是正确的，将要输出的内容通过 helloworld 传递给 axhal，这样只需要两个组件就能实现应用程序 helloworld 的运行和输出。

--- a/docs/src/ch03-03.md
+++ b/docs/src/ch03-03.md
@@ -16,7 +16,7 @@ helloworld --> axruntime --> axhal
 运行命令：
 
 ```shell
-make ARCH= riscv64 A=apps/helloworld run LOG=debug
+make PLATFORM=riscv64-qemu-virt A=apps/helloworld run LOG=debug
 ```
 
 运行结果如下图，下面的调试输出信息绿色字体部分可以为我们直观地展示 axruntime 做的一些初始化的工作。
@@ -28,7 +28,7 @@ make ARCH= riscv64 A=apps/helloworld run LOG=debug
 例如，运行 yield 应用程序 (FIFO scheduler): 
 
 ```shell
-make A=apps/task/yield ARCH=riscv64 LOG=info NET=y SMP=1 run
+make A=apps/task/yield PLATFORM=riscv64-qemu-virt LOG=info NET=y SMP=1 run
 ```
 
 运行结果: 

--- a/docs/src/ch03-04.md
+++ b/docs/src/ch03-04.md
@@ -44,7 +44,7 @@ graph TD
 
 ```toml
 [dependencies]
-libax = { path = "../../ulib/libax", features=["alloc"]} #尝试添加动态分配内存的feature
+axstd = { path = "../../ulib/axstd", features=["alloc"], optional = true } #尝试添加动态分配内存的feature
 ```
 
 之后，我们修改 apps/helloworld/src/main.rs，尝试使用 alloc 特性提供的动态分配内存功能：
@@ -53,9 +53,9 @@ libax = { path = "../../ulib/libax", features=["alloc"]} #尝试添加动态分�
 #![no_std]
 #![no_main]
 
-use libax::println;
+use axstd::println;
 #为 helloworld 提供可以动态内存分配的字符串类型
-use libax::string::String;
+use axstd::string::String;
 
 #[no_mangle]
 fn main() {
@@ -65,9 +65,9 @@ fn main() {
 }
 ```
 
-运行```make A=apps/helloworld ARCH=riscv64 LOG=info run```，此时运行结果如下图所示：
+运行```make PLATFORM=riscv64-qemu-virt A=apps/helloworld run```，此时运行结果如下图所示：
 
-![](https://s3.bmp.ovh/imgs/2023/07/08/12879bc9837566bb.png)
+![](https://s3.bmp.ovh/imgs/2023/08/24/60e8ff4c63aa0d80.png)
 
 打印出”Hello world! I am ArceOS"，说明我们成功为 helloworld 提供了动态内存分配功能。
 

--- a/docs/src/ch03-05.md
+++ b/docs/src/ch03-05.md
@@ -7,22 +7,22 @@
 以向屏幕打印日志信息为例，如果想要修改日志的过滤等级，例如，展示出 warn 级以上的日志（info 日志不会打印到屏幕上），可以修改原来的运行命令，这里还是以 qemu risv64 平台为例，原始命令为：
 
 ```bash
-make A=apps/helloworld ARCH=riscv64 LOG=info run
+make A=apps/helloworld PLATFORM=riscv64-qemu-virt LOG=info run
 ```
 
 尝试运行一下，发现 info 以上级别的日志会被打印出来（提示：绿色字体所在行为 info 级别的日志信息）：
 
-![](https://s3.bmp.ovh/imgs/2023/07/08/70bcb2d5d8955ed2.png)
+![](https://s3.bmp.ovh/imgs/2023/08/24/5706b1bcd08e415a.png)
 
 如果修改 log 日志等级：
 
 ```bash
-make A=apps/helloworld ARCH=riscv64 LOG=warn run
+make A=apps/helloworld PLATFORM=riscv64-qemu-virt LOG=warn run
 ```
 
 此时能够展示日志的最低级别提高到 warn，之前 info 级别的日志不会被打印到屏幕中，尝试运行上述命令，运行结果如下：
 
-![](https://s3.bmp.ovh/imgs/2023/07/08/ff2b0cf439009c81.png)
+![](https://s3.bmp.ovh/imgs/2023/08/24/d8b314bf0939c624.png)
 
 我们可以看到之前展示出来绿色字体的 info 日志行都消失了。
 


### PR DESCRIPTION
由于最上层服务命名统一规范化的原因，导致第三章的部分内容涉及到的执行命令已经无法使用，我对这些内容进行了调整，保证可以在ArceOS的最新版本上正常执行。
涉及文件：ch03-01.md，ch03-02.md，ch03-03.md，ch03-04.md，ch03-05.md。
涉及内容：文档展示的部分命令以及执行成功的截图。