### PR TITLE
Fix error in Chapter 1 (ch01-02)

### DIFF
--- a/docs/src/ch01-02.md
+++ b/docs/src/ch01-02.md
@@ -17,8 +17,8 @@ curl https://sh.rustup.rs -sSf | sh
 或者使用 tuna 源来加速 [参见 rustup 帮助](https://mirrors.tuna.tsinghua.edu.cn/help/rustup/)：
 
 ```bash
-export RUSTUP_DIST_SERVER=https://mirrors.tuna.edu.cn/rustup
-export RUSTUP_UPDATE_ROOT=https://mirrors.tuna.edu.cn/rustup/rustup
+export RUSTUP_DIST_SERVER=https://mirrors.tuna.tsinghua.edu.cn/rustup
+export RUSTUP_UPDATE_ROOT=https://mirrors.tuna.tsinghua.edu.cn/rustup/rustup
 curl https://sh.rustup.rs -sSf | sh
 ```
 


### PR DESCRIPTION
Correct mirror URL for Tsinghua University.
The URL in the document is https://mirrors.tuna.edu.cn/rustup but actually it is https://mirrors.tuna.tsinghua.edu.cn/rustup.
Details see [Rustup helps](https://mirrors.tuna.tsinghua.edu.cn/help/rustup)